### PR TITLE
Add element-specific audio sensitivity and orbital color controls

### DIFF
--- a/atomic.zgeproj
+++ b/atomic.zgeproj
@@ -16,9 +16,12 @@
     <DefineVariable Name="BASE_GAIN_MIN"  Value="0.5"/>
     <DefineVariable Name="BASE_GAIN_DEF"  Value="1.0"/>
     <DefineVariable Name="BASE_GAIN_MAX"  Value="5.0"/>
-    <DefineVariable Name="BASE_SENS_MIN"  Value="0.7"/>
-    <DefineVariable Name="BASE_SENS_DEF"  Value="1.0"/>
-    <DefineVariable Name="BASE_SENS_MAX"  Value="1.3"/>
+    <DefineVariable Name="BASE_NUC_SENS_MIN"  Value="0.0"/>
+    <DefineVariable Name="BASE_NUC_SENS_DEF"  Value="1.0"/>
+    <DefineVariable Name="BASE_NUC_SENS_MAX"  Value="2.0"/>
+    <DefineVariable Name="BASE_ORB_SENS_MIN"  Value="0.0"/>
+    <DefineVariable Name="BASE_ORB_SENS_DEF"  Value="1.0"/>
+    <DefineVariable Name="BASE_ORB_SENS_MAX"  Value="2.0"/>
     <!-- Gate & smoothing -->
     <DefineVariable Name="DRIVE_GATE"     Value="0.18"/>   <!-- below => 0 -->
     <DefineVariable Name="DRIVE_LP_ALPHA" Value="0.94"/>   <!-- closer 1 = smoother -->
@@ -90,9 +93,9 @@
     <DefineVariable Name="DEF_ElecA" Value="1.0"/>
 
     <!-- ====== UI Sliders ====== -->
-    <DefineArray Name="Parameters" SizeDim1="24"/>
+    <DefineArray Name="Parameters" SizeDim1="33"/>
     <DefineConstant Name="ParamHelpConst" Type="2"
-      StringValue="Audio Gain&#10;Sensitivity&#10;Smoothness&#10;Animation Speed&#10;Orbital Size&#10;Density Gain&#10;Nucleus Radius&#10;Nucleus Dot Size&#10;BG Hue&#10;BG Sat&#10;BG Light&#10;BG Alpha&#10;Proton Hue&#10;Proton Sat&#10;Proton Light&#10;Proton Alpha&#10;Neutron Hue&#10;Neutron Sat&#10;Neutron Light&#10;Neutron Alpha&#10;Electron Hue&#10;Electron Sat&#10;Electron Light&#10;Electron Alpha"/>
+      StringValue="Audio Gain&#10;Nucleus Sensitivity&#10;Smoothness&#10;Animation Speed&#10;Orbital Size&#10;Density Gain&#10;Nucleus Radius&#10;Nucleus Dot Size&#10;BG Hue&#10;BG Sat&#10;BG Light&#10;BG Alpha&#10;Proton Hue&#10;Proton Sat&#10;Proton Light&#10;Proton Alpha&#10;Neutron Hue&#10;Neutron Sat&#10;Neutron Light&#10;Neutron Alpha&#10;Electron Hue&#10;Electron Sat&#10;Electron Light&#10;Electron Alpha&#10;Pos Hue&#10;Pos Sat&#10;Pos Light&#10;Pos Alpha&#10;Neg Hue&#10;Neg Sat&#10;Neg Light&#10;Neg Alpha&#10;Orbital Sensitivity"/>
 
     <!-- ====== Runtime state / uniforms ====== -->
     <DefineVariable Name="Drive"     Value="0.0"/>
@@ -107,6 +110,8 @@
     <DefineVariable Name="StepMul"   Value="1.00"/>
     <DefineVariable Name="NucR"      Value="0.08"/>
     <DefineVariable Name="NucDot"    Value="0.016"/>
+    <DefineVariable Name="NucSens"   Value="1.0"/>
+    <DefineVariable Name="OrbSens"   Value="1.0"/>
 
     <!-- Phase integrator -->
     <DefineVariable Name="Phase"     Value="0.0"/>
@@ -162,7 +167,7 @@ uniform float uTime, uDrive, uSmooth, uAnimSpeed, uAspect, uPhase;
 
 /* user uniforms */
 uniform float uOrbScale, uDensity, uStepMul;
-uniform float uNucR, uNucDot;
+uniform float uNucR, uNucDot, uNucSens, uOrbSens;
 
 /* HSLA uniforms */
 uniform float uBGH,uBGS,uBGL,uBGA;
@@ -179,7 +184,6 @@ const int   VOL_STEPS = 96;
 const float STEP_LEN0 = (2.0*HALF_Z)/float(VOL_STEPS);
 
 const float ORB_S_1S=0.80, ORB_S_2S=0.30, ORB_S_2P=0.25;
-const float ORB_AUDIO_EXPAND=0.50;
 
 const float DENS_PEAK_GAIN=3.5;
 
@@ -224,21 +228,25 @@ float famScale(int s){
 }
 
 vec3 swirl(vec3 p, float d){
-  float amp = (0.30 + 0.90*d) * mix(1.0, 0.5, uSmooth);
-  float spd = 0.31 * mix(1.0, 0.6, uSmooth);
-  float s = sin(spd*uTime + 0.7*d), c = cos(spd*uTime + 0.7*d);
+  float amp = 0.30 * mix(1.0, 0.5, uSmooth);
+  float baseSpd = 0.31 * mix(1.0, 0.6, uSmooth);
+  float dEase = mix(d, d*d*(3.0 - 2.0*d), uSmooth);
+  float spd = baseSpd * (1.0 + 2.0*dEase);
+  float s = sin(spd*uTime), c = cos(spd*uTime);
   vec3 q = vec3( c*p.x + s*p.z, p.y, -s*p.x + c*p.z );
-  float w = 0.35 * (1.0 + 2.0*d) * mix(1.0, 0.5, uSmooth)
+  float w = 0.35 * mix(1.0, 0.5, uSmooth)
           * sin( (q.y*1.7 + q.x*1.1 + q.z*1.3) * 3.3 + 0.9*uTime );
   vec3 n = normalize(vec3(q.x+0.003, q.y-0.004, q.z+0.005));
   q += w*n;
-  float sy=sin(0.2*uTime*(1.0+d)), cy=cos(0.2*uTime*(1.0+d));
+  float sy=sin(0.2*uTime*(1.0 + dEase)), cy=cos(0.2*uTime*(1.0 + dEase));
   q = vec3(cy*q.x + sy*q.y, -sy*q.x + cy*q.y, q.z);
+  float sx=sin(0.25*uTime*(1.0 + dEase)), cx=cos(0.25*uTime*(1.0 + dEase));
+  q = vec3(q.x, cx*q.y + sx*q.z, -sx*q.y + cx*q.z);
   return mix(p, q, amp);
 }
 
 float psiAt(int s, vec3 p, float drive){
-  float sc = max(1e-3, uOrbScale * famScale(s) * (1.0 + ORB_AUDIO_EXPAND*drive));
+  float sc = max(1e-3, uOrbScale * famScale(s));
   vec3  q  = swirl(p/sc, drive);
   float r,th,ph; cart2sph(q,r,th,ph);
   if(s==0) return Y00(th,ph)*R10(r);
@@ -271,8 +279,9 @@ vec4  elecHSLA(){ return vec4(hsl2rgb(vec3(uElecH,uElecS,uElecL)), uElecA); }
 vec3 nucleus(vec2 uv01){
   vec3 col=vec3(0.0); int NP=int(PROTONS+0.5), NN=int(NEUTRONS+0.5), NT=NP+NN;
   if(NT<1) return col; if(NT>NUC_MAX) NT=NUC_MAX;
-  float drive = clamp(uDrive,0.0,1.0);
-  float jitter = NUC_JITTER * (1.0 + 2.5*drive) * mix(1.0, 0.4, uSmooth);
+  float drive = clamp(uDrive * uNucSens,0.0,1.0);
+  float dEase = mix(drive, drive*drive*(3.0 - 2.0*drive), uSmooth);
+  float jitter = NUC_JITTER * (1.0 + 2.5*dEase) * mix(1.0, 0.4, uSmooth);
   vec4 pHSLA = protHSLA();
   vec4 nHSLA = neutHSLA();
   for(int k=0;k<NUC_MAX;k++){
@@ -281,7 +290,7 @@ vec3 nucleus(vec2 uv01){
     float z = 1.0 - 2.0*m/float(NT);
     float r = sqrt(max(0.0,1.0 - z*z));
     float th= 2.3999632297 * m;
-    vec3 p = vec3(r*cos(th), r*sin(th), z) * uNucR * (1.0 + 0.5*drive);
+    vec3 p = vec3(r*cos(th), r*sin(th), z) * uNucR;
 
     vec3 j = vec3(
       sin(1.9*uTime + 4.1*hash1(5.7*m)),
@@ -291,11 +300,11 @@ vec3 nucleus(vec2 uv01){
     p += j;
 
     vec2 n01 = (p.xy * ZOOM) / vec2(uAspect,1.0) * 0.5 + 0.5;
-    float sigma = uNucDot * ZOOM * (1.0 + 0.8*drive);
+    float sigma = uNucDot * ZOOM;
     float d = length(uv01 - n01);
     float g = exp(-pow(d/(sigma+1e-6),2.0));
     vec3 c = (k<NP) ? pHSLA.rgb*pHSLA.a : nHSLA.rgb*nHSLA.a;
-    col += c*g*(1.0 + drive);
+    col += c*g;
   }
   return col;
 }
@@ -303,7 +312,7 @@ vec3 nucleus(vec2 uv01){
 void main(){
   vec3 col = bgRGB();
 
-  float d  = clamp(uDrive, 0.0, 1.0);
+  float dOrb = clamp(uDrive * uOrbSens, 0.0, 1.0);
   float st = uPhase;
 
   float stepLen = STEP_LEN0 * max(0.5, uStepMul);
@@ -320,13 +329,13 @@ void main(){
   for(int i=0;i<VOL_STEPS;i++){
     float z = -HALF_Z + (float(i)+0.5)*stepLen;
     vec3  p = ro + rd*(z+HALF_Z);
-    float psi = psiMix(p, st, d);
+    float psi = psiMix(p, st, dOrb);
     float pos = max(psi, 0.0), neg = max(-psi, 0.0);
     float rPos= pos*pos, rNeg=neg*neg;
 
     float rho = (rPos + rNeg);
 
-    float k    = uDensity * (1.0 + 2.0*d) * kComp;
+    float k    = uDensity * kComp;
     float a    = 1.0 - exp(-k * rho * stepLen);
     a = clamp(a, 0.0, 1.0);
 
@@ -362,6 +371,8 @@ void main(){
 
         <ShaderVariable VariableName="uNucR"       VariableRef="NucR"/>
         <ShaderVariable VariableName="uNucDot"     VariableRef="NucDot"/>
+        <ShaderVariable VariableName="uNucSens"    VariableRef="NucSens"/>
+        <ShaderVariable VariableName="uOrbSens"    VariableRef="OrbSens"/>
 
         <ShaderVariable VariableName="uBGH" VariableRef="uBGH"/>
         <ShaderVariable VariableName="uBGS" VariableRef="uBGS"/>
@@ -426,6 +437,15 @@ Parameters[20]=0.5;
 Parameters[21]=0.5;
 Parameters[22]=0.5;
 Parameters[23]=0.5;
+Parameters[24]=0.5;
+Parameters[25]=0.5;
+Parameters[26]=0.5;
+Parameters[27]=0.5;
+Parameters[28]=0.5;
+Parameters[29]=0.5;
+Parameters[30]=0.5;
+Parameters[31]=0.5;
+Parameters[32]=0.5;
 ]]></Expression></ZExpression>
   </OnLoaded>
 
@@ -455,15 +475,11 @@ else
   AnimSpeed = BASE_AS_DEF + (BASE_AS_MAX - BASE_AS_DEF) * (a * 2.0 - 1.0);
 ]]></Expression></ZExpression>
 
-    <!-- Audio drive (gain, sensitivity, gate, LP) -->
+    <!-- Audio drive (gain, gate, LP) -->
     <ZExpression><Expression><![CDATA[
 float g = Parameters[0];
 float gain = (g < 0.5) ? (BASE_GAIN_MIN + (BASE_GAIN_DEF - BASE_GAIN_MIN)*(g*2.0))
                        : (BASE_GAIN_DEF + (BASE_GAIN_MAX - BASE_GAIN_DEF)*(g*2.0-1.0));
-
-float s = Parameters[1];
-float mult = (s < 0.5) ? (BASE_SENS_MIN + (BASE_SENS_DEF - BASE_SENS_MIN)*(s*2.0))
-                       : (BASE_SENS_DEF + (BASE_SENS_MAX - BASE_SENS_DEF)*(s*2.0-1.0));
 
 /* 5-band average */
 float b1=SpecBandArray[1];  if(b1<0.0)b1=-b1;
@@ -473,7 +489,7 @@ float b10=SpecBandArray[10];if(b10<0.0)b10=-b10;
 float b15=SpecBandArray[15];if(b15<0.0)b15=-b15;
 float sAvg = (b1+b3+b6+b10+b15)/5.0;
 
-float raw = sAvg * gain * mult;
+float raw = sAvg * gain;
 if (raw < DRIVE_GATE) raw = 0.0;
 if (raw > 1.0) raw = 1.0;
 
@@ -488,6 +504,15 @@ Phase    = Phase + HzSmooth * 0.016;
     <!-- Engine sliders -->
     <ZExpression><Expression><![CDATA[
 float v;
+/* Nucleus sensitivity */
+v = Parameters[1];
+if (v < 0.5) NucSens = BASE_NUC_SENS_MIN + (BASE_NUC_SENS_DEF - BASE_NUC_SENS_MIN) * (v * 2.0);
+else         NucSens = BASE_NUC_SENS_DEF + (BASE_NUC_SENS_MAX - BASE_NUC_SENS_DEF) * (v * 2.0 - 1.0);
+
+/* Orbital sensitivity */
+v = Parameters[32];
+if (v < 0.5) OrbSens = BASE_ORB_SENS_MIN + (BASE_ORB_SENS_DEF - BASE_ORB_SENS_MIN) * (v * 2.0);
+else         OrbSens = BASE_ORB_SENS_DEF + (BASE_ORB_SENS_MAX - BASE_ORB_SENS_DEF) * (v * 2.0 - 1.0);
 
 /* Orbital size */
 v = Parameters[4];
@@ -534,6 +559,16 @@ def = DEF_ElecH/360.0; q = Parameters[20]; if(q<0.5) uElecH=def*(q*2.0); else uE
 q = Parameters[21]; if(q<0.5) uElecS=0.0 + (DEF_ElecS-0.0)*(q*2.0); else uElecS=DEF_ElecS + (1.0-DEF_ElecS)*(q*2.0-1.0);
 q = Parameters[22]; if(q<0.5) uElecL=0.0 + (DEF_ElecL-0.0)*(q*2.0); else uElecL=DEF_ElecL + (1.0-DEF_ElecL)*(q*2.0-1.0);
 q = Parameters[23]; if(q<0.5) uElecA=0.0 + (DEF_ElecA-0.0)*(q*2.0); else uElecA=DEF_ElecA + (1.0-DEF_ElecA)*(q*2.0-1.0);
+/* Pos orbital */
+def = DEF_PosH/360.0; q = Parameters[24]; if(q<0.5) uPosH = def*(q*2.0); else uPosH = def + (1.0-def)*(q*2.0-1.0);
+q = Parameters[25]; if(q<0.5) uPosS = 0.0 + (DEF_PosS-0.0)*(q*2.0); else uPosS = DEF_PosS + (1.0-DEF_PosS)*(q*2.0-1.0);
+q = Parameters[26]; if(q<0.5) uPosL = 0.0 + (DEF_PosL-0.0)*(q*2.0); else uPosL = DEF_PosL + (1.0-DEF_PosL)*(q*2.0-1.0);
+q = Parameters[27]; if(q<0.5) uPosA = 0.0 + (DEF_PosA-0.0)*(q*2.0); else uPosA = DEF_PosA + (1.0-DEF_PosA)*(q*2.0-1.0);
+/* Neg orbital */
+def = DEF_NegH/360.0; q = Parameters[28]; if(q<0.5) uNegH = def*(q*2.0); else uNegH = def + (1.0-def)*(q*2.0-1.0);
+q = Parameters[29]; if(q<0.5) uNegS = 0.0 + (DEF_NegS-0.0)*(q*2.0); else uNegS = DEF_NegS + (1.0-DEF_NegS)*(q*2.0-1.0);
+q = Parameters[30]; if(q<0.5) uNegL = 0.0 + (DEF_NegL-0.0)*(q*2.0); else uNegL = DEF_NegL + (1.0-DEF_NegL)*(q*2.0-1.0);
+q = Parameters[31]; if(q<0.5) uNegA = 0.0 + (DEF_NegA-0.0)*(q*2.0); else uNegA = DEF_NegA + (1.0-DEF_NegA)*(q*2.0-1.0);
 ]]></Expression></ZExpression>
 
     <!-- Fullscreen draw via your scaling group -->


### PR DESCRIPTION
## Summary
- Allow separate audio sensitivities for nucleus motion and orbital animation speed
- Expose HSLA sliders for positive/negative orbitals and individual sensitivity controls
- Remove audio-based density/size scaling and enhance orbital swirl for a 3D look

## Testing
- `xmllint --noout atomic.zgeproj` *(fails: xmlParseEntityRef: no name)*

------
https://chatgpt.com/codex/tasks/task_e_68c0cb84e0d483338c5a187a83cd186b